### PR TITLE
chore: loosen algolia & rails dependency, add ruby 3.4

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,6 +9,7 @@ jobs:
           - 3.1
           - 3.2
           - 3.3
+          - 3.4
 
     runs-on: ubuntu-latest
     steps:

--- a/appsignal-sourcemap.gemspec
+++ b/appsignal-sourcemap.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["lib/**/*", "README.md"]
 
-  spec.add_dependency "rails", ">= 6.1", "< 8.0"
+  spec.add_dependency "rails", ">= 6.1", "< 9.0"
   spec.add_dependency "appsignal", "< 5.0"
   spec.add_dependency "parallel", "~> 1.0"
 

--- a/appsignal-sourcemap.gemspec
+++ b/appsignal-sourcemap.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*", "README.md"]
 
   spec.add_dependency "rails", ">= 6.1", "< 8.0"
-  spec.add_dependency "appsignal", "~> 3.0"
+  spec.add_dependency "appsignal", "< 5.0"
   spec.add_dependency "parallel", "~> 1.0"
 
   spec.add_development_dependency "standard"

--- a/lib/appsignal/sourcemap/version.rb
+++ b/lib/appsignal/sourcemap/version.rb
@@ -2,6 +2,6 @@
 
 module Appsignal
   module Sourcemap
-    VERSION = "1.1.1.develop"
+    VERSION = "1.2.1.develop"
   end
 end


### PR DESCRIPTION
after looking into the code of this gem and the [upgrade guide](https://docs.appsignal.com/ruby/installation/upgrade-from-3-to-4.html), I couldn't find anything that would block this upgrade path as the API stayed consistent. 