### PR TITLE
chore: Remove reviewdog

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,7 +1,7 @@
-name: reviewdog
+name: linters
 on: push
 jobs:
-  rubocop:
+  standardrb:
     strategy:
       fail-fast: false
       matrix:
@@ -22,10 +22,5 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1
-
-      - name: Run linters with Reviewdog
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: reviewdog -fail-on-error -tee -reporter=github-check
+      - name: Run standardrb
+        run: bundle exec standardrb

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -1,4 +1,0 @@
----
-runner:
-  standardrb:
-    cmd: bundle exec standardrb


### PR DESCRIPTION
Reviewdog has been compromised and may have leaked repository secrets. It is safer to get rid of reviewdog entirely.

See: https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup